### PR TITLE
Task 3: K8s Cluster Configuration and Creation

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -4,13 +4,22 @@ on:
   push:
     branches:
       - main
-      - task_2
+      - task_3
 
   pull_request:
     branches:
       - main
 env:
   AWS_REGION: eu-central-1
+  TF_VAR_bucket_name: ${{ secrets.BUCKET_NAME }}
+  TF_VAR_client_id_list: ${{ secrets.CLIENT_ID_LIST }}
+  TF_VAR_thumbprint_list: ${{ secrets.THUMBPRINT_LIST }}
+  TF_VAR_github_actions_role_name: ${{ secrets.ACTIONS_ROLE_NAME }}
+  TF_VAR_oidc_provider_url: ${{ secrets.OIDC_PROVIDER_URL }}
+  TF_VAR_github_actions_condition: ${{ secrets.ACTIONS_CONDITION }}
+  TF_VAR_iam_policies: ${{ secrets.IAM_POLICIES }}
+  TF_VAR_key_name: ${{ secrets.KEY_NAME }}
+  TF_VAR_k3s_token: ${{ secrets.K3S_TOKEN }}
 
 permissions:
   id-token: write
@@ -49,23 +58,17 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GithubActionsRole
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Create tfvars file
+      - name: Write SSH private key
         run: |
-          cat << EOF > terraform.tfvars
-          bucket_name = "${{ secrets.BUCKET_NAME }}"
-          client_id_list = ${{ secrets.CLIENT_ID_LIST }}
-          thumbprint_list = ${{ secrets.THUMBPRINT_LIST }}
-          github_actions_role_name = "${{ secrets.ACTIONS_ROLE_NAME }}"
-          oidc_provider_url = "${{ secrets.OIDC_PROVIDER_URL }}"
-          github_actions_condition = "${{ secrets.ACTIONS_CONDITION }}"
-          iam_policies = ${{ secrets.IAM_POLICIES }}
-          key_name = "${{ secrets.KEY_NAME }}"
-          EOF
+          echo "${{ secrets.WEBSERVER_LINUX_PRIVATE_KEY }}" > /tmp/bastion_key.pem
+          chmod 600 /tmp/bastion_key.pem      
 
       - name: Terraform Init
         run:  terraform init
 
       - name: Terraform Plan
+        env:
+          TF_VAR_private_key_path: /tmp/bastion_key.pem
         run:  terraform plan
 
   terraform-apply:
@@ -85,21 +88,15 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GithubActionsRole
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Create tfvars file
+      - name: Write SSH private key
         run: |
-          cat << EOF > terraform.tfvars
-          bucket_name = "${{ secrets.BUCKET_NAME }}"
-          client_id_list = ${{ secrets.CLIENT_ID_LIST }}
-          thumbprint_list = ${{ secrets.THUMBPRINT_LIST }}
-          github_actions_role_name = "${{ secrets.ACTIONS_ROLE_NAME }}"
-          oidc_provider_url = "${{ secrets.OIDC_PROVIDER_URL }}"
-          github_actions_condition = "${{ secrets.ACTIONS_CONDITION }}"
-          iam_policies = ${{ secrets.IAM_POLICIES }}
-          key_name = "${{ secrets.KEY_NAME }}"
-          EOF
+             echo "${{ secrets.WEBSERVER_LINUX_PRIVATE_KEY }}" > /tmp/bastion_key.pem
+             chmod 600 /tmp/bastion_key.pem
 
       - name: Terraform Init
         run: terraform init
 
       - name: Terraform Apply
+        env:
+          TF_VAR_private_key_path: /tmp/bastion_key.pem
         run: terraform apply -auto-approve

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -58,17 +58,10 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GithubActionsRole
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Write SSH private key
-        run: |
-          echo "${{ secrets.WEBSERVER_LINUX_PRIVATE_KEY }}" > /tmp/bastion_key.pem
-          chmod 600 /tmp/bastion_key.pem      
-
       - name: Terraform Init
         run:  terraform init
 
       - name: Terraform Plan
-        env:
-          TF_VAR_private_key_path: /tmp/bastion_key.pem
         run:  terraform plan
 
   terraform-apply:
@@ -88,15 +81,8 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GithubActionsRole
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Write SSH private key
-        run: |
-             echo "${{ secrets.WEBSERVER_LINUX_PRIVATE_KEY }}" > /tmp/bastion_key.pem
-             chmod 600 /tmp/bastion_key.pem
-
       - name: Terraform Init
         run: terraform init
 
       - name: Terraform Apply
-        env:
-          TF_VAR_private_key_path: /tmp/bastion_key.pem
         run: terraform apply -auto-approve

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.0.0"
+  hashes = [
+    "h1:DhxTTyLjzmC0wRCodYOWkIGwHAYb2Fcg3zFc/3sIpvk=",
+    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
+    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
+    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
+    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
+    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
+    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
+    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
+    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
+    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
+    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
+    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
+    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
+    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ ______________________________________________
 ## Project Overview
 
 This project contains Terraform configuration for creating AWS infrastructure with automated CI/CD pipeline through GitHub Actions.
+It also includes the setup and verification of a lightweight Kubernetes cluster (k3s) deployed on EC2 instances, accessible via a bastion host.
+
 
 ## 🏗️ Infrastructure Architecture
 
@@ -20,7 +22,7 @@ The infrastructure includes the following components:
 - **Route Tables** - traffic routing
 
 ### Compute Resources
-- **EC2 Instances** - virtual machines (including bastion host)
+- **EC2 Instances** - virtual machines (including: bastion host and k3s control plane and worker nodes)
 - **Security Groups** - firewall rules
 - **ACL** - additional network security layer
 
@@ -33,11 +35,32 @@ The infrastructure includes the following components:
 - **OIDC Provider** - secure authentication with AWS
 - **IAM Roles** - access management for GitHub Actions
 
+### Kubernetes Cluster with k3s
+🚀 Deployment
+- **Deployed via EC2 Instances** - using AWS Free Tier
+- **Lightweight K3s Distribution** – installed on EC2
+- **Access via Bastion Host** – SSH access and kubectl commands
+- **Local Access** – configure SSH tunneling to interact from local machine
+
+### ✅ Cluster Verification
+- Confirmed cluster with kubectl get nodes on bastion host
+- Deployed a test workload with:
+```
+  kubectl apply -f https://k8s.io/examples/pods/simple-pod.yaml
+```
+
+### 🔐 Security
+- SSH access only via Bastion
+- Security Groups restrict access to necessary ports (22, 6443, etc.)
+- IAM roles limited to required resources only
+
 ## 📋 Prerequisites
 
 - AWS account with appropriate permissions
 - Terraform >= 1.12.1
 - GitHub repository with configured secrets
+- SSH key pair for EC2 instances
+- kubectl for cluster interaction
 
 ## 🔧 GitHub Secrets Configuration
 
@@ -52,7 +75,8 @@ OIDC_PROVIDER_URL - OIDC provider URL
 ACTIONS_CONDITION - OIDC conditions 
 IAM_POLICIES - List of IAM policies 
 KEY_NAME - EC2 Key Pair name
-``` 
+K3S_TOKEN - Shared secret token used by K3s server and agent nodes for cluster join
+```
 
 ## 🚀 Deployment
 
@@ -62,14 +86,12 @@ KEY_NAME - EC2 Key Pair name
 2. **Pull Request** - triggers validation and planning
 
 ### Manual Deployment
-
-```bash
+1. Clone this repository
+2. Configure your `terraform.tfvars`
+3. Run:
+```
 # Initialize Terraform
 terraform init
-
-# Create variables file
-cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars with your values
 
 # Plan changes
 terraform plan
@@ -85,10 +107,10 @@ terraform apply
 │   └── workflows/
 │       └── terraform.yaml          # CI/CD pipeline
 ├── acl.tf                          # Network ACL configuration
-├── ec2.tf                          # EC2 instances
+├── ec2.tf                          # EC2 instances (bastion host, k3s nodes)
 ├── vpc.tf                          # VPC configuration
 ├── nat_gateway.tf                  # NAT Gateway
-├── security_groups.tf              # Security Groups
+├── security_groups.tf              # Security Groups configuration
 ├── route_table_public_subnets.tf   # Routes for public subnets
 ├── route_table_private_subnets.tf  # Routes for private subnets
 ├── github_actions_role.tf          # IAM role for GitHub Actions
@@ -137,6 +159,7 @@ If you encounter issues:
 1. Check GitHub Actions logs
 2. Verify secrets configuration
 3. Check IAM role permissions
+4. Verify SSH and Security Group access
 
 ## Contact
 For questions, reach out to: anikejoksana@gmail.com

--- a/ec2.tf
+++ b/ec2.tf
@@ -39,26 +39,41 @@ resource "aws_instance" "Second_public_instance" {
   }
 }
 
-resource "aws_instance" "First_private_instance" {
+
+locals {
+  control_plane_ip = aws_instance.k3s_control_plane.private_ip
+}
+
+resource "aws_instance" "k3s_control_plane" {
   ami                    = data.aws_ami.latest_ami_ubuntu.id
   instance_type          = "t2.micro"
   subnet_id              = aws_subnet.private_subnet_1.id
   vpc_security_group_ids = [aws_security_group.private_sg.id]
   key_name               = var.key_name
 
-  tags = {
-    Name = "Private instance 1"
+
+  user_data = <<-EOF
+              #!/bin/bash
+              curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server' K3S_TOKEN=${var.k3s_token} K3S_KUBECONFIG_MODE='644' sh -s -
+              EOF
+tags = {
+    Name = "k3s Control Plane"
   }
 }
 
-resource "aws_instance" "Second_private_instance" {
+resource "aws_instance" "k3s_worker_node" {
+  depends_on = [aws_instance.k3s_control_plane]
   ami                    = data.aws_ami.latest_ami_ubuntu.id
   instance_type          = "t2.micro"
   subnet_id              = aws_subnet.private_subnet_2.id
   vpc_security_group_ids = [aws_security_group.private_sg.id]
   key_name               = var.key_name
-
+  user_data = <<-EOF
+              #!/bin/bash
+              K3S_URL="https://${aws_instance.k3s_control_plane.private_ip}:6443"
+              curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --server $K3S_URL --token ${var.k3s_token}" sh -s -
+              EOF
   tags = {
-    Name = "Private instance 2"
+    Name = "k3S Worker Node"
   }
 }

--- a/ec2.tf
+++ b/ec2.tf
@@ -39,11 +39,6 @@ resource "aws_instance" "Second_public_instance" {
   }
 }
 
-
-locals {
-  control_plane_ip = aws_instance.k3s_control_plane.private_ip
-}
-
 resource "aws_instance" "k3s_control_plane" {
   ami                    = data.aws_ami.latest_ami_ubuntu.id
   instance_type          = "t2.micro"
@@ -56,19 +51,19 @@ resource "aws_instance" "k3s_control_plane" {
               #!/bin/bash
               curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server' K3S_TOKEN=${var.k3s_token} K3S_KUBECONFIG_MODE='644' sh -s -
               EOF
-tags = {
+  tags = {
     Name = "k3s Control Plane"
   }
 }
 
 resource "aws_instance" "k3s_worker_node" {
-  depends_on = [aws_instance.k3s_control_plane]
+  depends_on             = [aws_instance.k3s_control_plane]
   ami                    = data.aws_ami.latest_ami_ubuntu.id
   instance_type          = "t2.micro"
   subnet_id              = aws_subnet.private_subnet_2.id
   vpc_security_group_ids = [aws_security_group.private_sg.id]
   key_name               = var.key_name
-  user_data = <<-EOF
+  user_data              = <<-EOF
               #!/bin/bash
               K3S_URL="https://${aws_instance.k3s_control_plane.private_ip}:6443"
               curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --server $K3S_URL --token ${var.k3s_token}" sh -s -

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -32,7 +32,7 @@ resource "aws_security_group" "bastion_sg" {
 }
 
 resource "aws_security_group" "private_sg" {
-  name   = "private_sg"
+  name   = "k3s_cluster_sg"
   vpc_id = aws_vpc.DevOps_course_vpc.id
 
   ingress {
@@ -66,7 +66,29 @@ resource "aws_security_group" "private_sg" {
     protocol    = "icmp"
     cidr_blocks = ["10.0.0.0/16"]
   }
+  ingress {
+    description = "K3s API server (TCP 6443) from VPC"
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
 
+  ingress {
+    description = "Flannel VXLAN (UDP 8472) from VPC"
+    from_port   = 8472
+    to_port     = 8472
+    protocol    = "udp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  ingress {
+    description = "Kubelet metrics (TCP 10250) from VPC"
+    from_port   = 10250
+    to_port     = 10250
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
   egress {
     from_port        = 0
     to_port          = 0
@@ -76,7 +98,7 @@ resource "aws_security_group" "private_sg" {
   }
 
   tags = {
-    Name = "PrivateSG"
+    Name = "k3s cluster SG"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,37 +6,37 @@ variable "region" {
 variable "bucket_name" {
   description = "Name of the S3 bucket for remote state"
   type        = string
-  sensitive = true
+  sensitive   = true
 }
 
 variable "oidc_provider_url" {
   description = "URL of the OIDC provider"
   type        = string
-  sensitive = true
+  sensitive   = true
 }
 
 variable "client_id_list" {
   description = "List of client IDs for the OIDC provider"
   type        = list(string)
-  sensitive = true
+  sensitive   = true
 }
 
 variable "thumbprint_list" {
   description = "List of thumbprints for the OIDC provider"
   type        = list(string)
-  sensitive = true
+  sensitive   = true
 }
 
 variable "github_actions_role_name" {
   description = "Name of the IAM role for GitHub Actions"
   type        = string
-  sensitive = true
+  sensitive   = true
 }
 
 variable "github_actions_condition" {
   description = "Condition for the GitHub Actions trust policy"
   type        = string
-  sensitive = true
+  sensitive   = true
 }
 
 variable "iam_policies" {
@@ -47,17 +47,11 @@ variable "iam_policies" {
 variable "key_name" {
   description = "SSH key pair name"
   type        = string
-  sensitive = true
-}
-
-variable "private_key_path" {
-    description = "Path to the private key file for SSH access"
-    type        = string
-  sensitive = true
+  sensitive   = true
 }
 
 variable "k3s_token" {
-    description = "Token for k3s cluster authentication"
-    type        = string
-    sensitive = true
+  description = "Token for k3s cluster authentication"
+  type        = string
+  sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,38 +6,58 @@ variable "region" {
 variable "bucket_name" {
   description = "Name of the S3 bucket for remote state"
   type        = string
+  sensitive = true
 }
 
 variable "oidc_provider_url" {
   description = "URL of the OIDC provider"
   type        = string
+  sensitive = true
 }
 
 variable "client_id_list" {
   description = "List of client IDs for the OIDC provider"
   type        = list(string)
+  sensitive = true
 }
 
 variable "thumbprint_list" {
   description = "List of thumbprints for the OIDC provider"
   type        = list(string)
+  sensitive = true
 }
 
 variable "github_actions_role_name" {
   description = "Name of the IAM role for GitHub Actions"
   type        = string
+  sensitive = true
 }
 
 variable "github_actions_condition" {
   description = "Condition for the GitHub Actions trust policy"
   type        = string
+  sensitive = true
 }
 
 variable "iam_policies" {
   description = "List of IAM policies to attach to the role"
   type        = list(string)
+
 }
 variable "key_name" {
   description = "SSH key pair name"
   type        = string
+  sensitive = true
+}
+
+variable "private_key_path" {
+    description = "Path to the private key file for SSH access"
+    type        = string
+  sensitive = true
+}
+
+variable "k3s_token" {
+    description = "Token for k3s cluster authentication"
+    type        = string
+    sensitive = true
 }


### PR DESCRIPTION
**1. Terraform Code for AWS Resources (10 points)**
- Terraform code is created or extended to manage AWS resources required for the cluster creation.
- The code includes the creation of a bastion host.
`You can see that in the "Files changed" tab.` or [click here](https://github.com/oksana-babich/rsschool-devops-course-tasks/pull/3/files)

**For your convenience when checking:**
**Bastion**   - Private IP 10.0.1.190        - Public IP 18.196.23.199
**k3s Control plane** - Private IP 10.0.3.214
**k3s Worker Node** - Private IP 10.0.4.214

`Bastion IPs`
![Bastion_IPs](https://github.com/user-attachments/assets/e163aca2-7e3f-4fdb-be39-87c1b1f05497)


`k3s Control plane IP`
![k3s_Control_plane_ip](https://github.com/user-attachments/assets/02e1b001-c697-4fbd-b72b-9c8443a40ab3)


`k3s Worker Node IP`
![k3s_Worker_node_IP](https://github.com/user-attachments/assets/1c516507-916f-45e2-8f97-afcc4d151fab)


**2. Cluster Verification (50 points)**
- The cluster is verified by running the `kubectl get nodes` command from the bastion host.
- k8s cluster consists of 2 nodes (may be checked on screenshot).
![get_nodes_from_bastion](https://github.com/user-attachments/assets/479b1476-dad9-44e4-9948-1f872bf1c68a)

**3. Workload Deployment (30 points)**
- A simple workload is deployed on the cluster using `kubectl apply -f https://k8s.io/examples/pods/simple-pod.yaml.`
- Pod named "nginx" presented in the output of `kubectl get all --all-namespaces` command
![nodes_and_namespaces_from_bastion](https://github.com/user-attachments/assets/521e4c52-a711-4e29-a9e4-02ea1ee192c2)

**4. Additional Tasks (10 points)💫**
- Documentation (5 points) Document the cluster setup and deployment process in a README file.
You can read it in the [README file here](https://github.com/oksana-babich/rsschool-devops-course-tasks/tree/task_3) or [here](https://github.com/oksana-babich/rsschool-devops-course-tasks/pull/3/files)

- Cluster accessability (5 points)
The cluster is verified by running the `kubectl get nodes` command from the `local computer`.
![get_nodes_from_localPC](https://github.com/user-attachments/assets/b35e3ddd-3d6c-418c-ad25-edb297e6cc71)
![namespace_from_local](https://github.com/user-attachments/assets/b2e806d3-6579-4eb2-8947-309a2c9316bc)

For access to cluster from the local computer used `sshuttle` connection
![shuttle_connection](https://github.com/user-attachments/assets/23c2e372-d2f6-4bea-8f57-1d9ce5221843)

